### PR TITLE
PHP 8 and Symfony 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 | ^8.0.2",
         "ext-openssl": "*",
         "symfony/console": "^4.1|^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 | ^8.0.2",
+        "php": "^7.2|^8.0",
         "ext-openssl": "*",
         "symfony/console": "^4.1|^5.0|^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require": {
         "php": "^7.2 | ^8.0.2",
         "ext-openssl": "*",
-        "symfony/console": "^4.1|^5.0"
+        "symfony/console": "^4.1|^5.0|^6.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.2"

--- a/src/Console/Command/ExportPublicKeyCommand.php
+++ b/src/Console/Command/ExportPublicKeyCommand.php
@@ -45,6 +45,11 @@ class ExportPublicKeyCommand extends Command
     public const DESCRIPTION = 'Export the public key with OpenSSL';
 
     /**
+     * Default name
+     */
+    protected static $defaultName = self::NAME;
+
+    /**
      * Configure command.
      *
      * @throws \InvalidArgumentException

--- a/src/Console/Command/ExportPublicKeyCommand.php
+++ b/src/Console/Command/ExportPublicKeyCommand.php
@@ -50,6 +50,11 @@ class ExportPublicKeyCommand extends Command
     protected static $defaultName = self::NAME;
 
     /**
+     * Default description
+     */
+    protected static $defaultDescription = self::DESCRIPTION;
+
+    /**
      * Configure command.
      *
      * @throws \InvalidArgumentException

--- a/src/Console/Command/GeneratePrivateKeyCommand.php
+++ b/src/Console/Command/GeneratePrivateKeyCommand.php
@@ -70,6 +70,11 @@ class GeneratePrivateKeyCommand extends Command
     protected static $defaultName = self::NAME;
 
     /**
+     * Default description
+     */
+    protected static $defaultDescription = self::DESCRIPTION;
+
+    /**
      * Configure command.
      *
      * @throws \InvalidArgumentException

--- a/src/Console/Command/GeneratePrivateKeyCommand.php
+++ b/src/Console/Command/GeneratePrivateKeyCommand.php
@@ -65,6 +65,11 @@ class GeneratePrivateKeyCommand extends Command
     public const DEFAULT_BITS = 2048;
 
     /**
+     * Default name
+     */
+    protected static $defaultName = self::NAME;
+
+    /**
      * Configure command.
      *
      * @throws \InvalidArgumentException


### PR DESCRIPTION
This pull request will allow the usage of this repository with PHP 8.0+, will allow the usage with the Symfony/console component 6.0+, will add the ability to lazy load the command by providing the `default name` and will add the ability for autocompletion by providing the `default description`.